### PR TITLE
Update cmake_minimum_required version to 3.10 in CMakeLists.txt with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cmake"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Fixes #1

Add a `dependabot.yml` file to configure Dependabot for updating the `cmake_minimum_required` version.

* **Dependabot Configuration**
  - Specify the version of Dependabot to use.
  - Define the package-ecosystem as `cmake`.
  - Set the directory to the root of the repository.
  - Set the update schedule to daily.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gounthar/casino-number-guessing-game/pull/2?shareId=f44688a0-ff4e-491e-836b-da3bb0db7ae0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced an automated configuration to handle dependency updates on a daily schedule, enhancing system maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->